### PR TITLE
Improve ProhibitedOperations

### DIFF
--- a/Lib/tools.mjs
+++ b/Lib/tools.mjs
@@ -113,13 +113,13 @@ function registerExecuteQueryTool(server, registerWithAllAliases) {
         
             // Basic validation to prevent destructive operations
             const lowerSql = sql.toLowerCase();
-            const prohibitedOperations = ['drop ', 'delete ', 'truncate ', 'update ', 'alter '];
+            const prohibitedOperations = ['drop', 'delete', 'truncate', 'update', 'alter', 'truncate', 'rename', 'insert', 'merge', 'upsert', 'grant', 'revoke', 'deny', 'create', 'writetext', 'updatetext', 'backup', 'restore', 'exec'];
             
             if (prohibitedOperations.some(op => lowerSql.includes(op))) {
                 return {
                     content: [{
                         type: "text",
-                        text: "⚠️ Error: Data modification operations (DROP, DELETE, UPDATE, TRUNCATE, ALTER) are not allowed for safety reasons."
+                        text: "⚠️ Error: Data modification operations (DROP, DELETE, UPDATE, TRUNCATE, ALTER and so on) are not allowed for safety reasons."
                     }],
                     isError: true
                 };


### PR DESCRIPTION
A lot of potential destructive operations were missing. Further, it was possible to bypass the denylist because of the trailing spaces. "drop " does not match e.g. "drop/**/ ".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `execute_query` safety check to block a much broader set of SQL keywords and removes the prior trailing-space matching, which may newly reject some previously-allowed queries (including false positives due to substring matching). Scope is small but impacts core query execution behavior.
> 
> **Overview**
> Tightens the `execute_query` tool’s destructive-operation guard by replacing the small keyword list (with trailing-space matching) with a much broader denylist (e.g., `insert`, `create`, `grant/revoke`, `backup/restore`, `exec`) to reduce bypasses via comments/whitespace.
> 
> Updates the returned validation error text to reflect the expanded set of blocked operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a013ec18a0f7e5806dfd6f73d0a947f97aed591e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->